### PR TITLE
Update for Craft 4 compatilibity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Entry Type Rules Changelog
-
+# 2.0.0 - 2022-05-20
+- Craft 4 compatibility
 ## 1.0.0 - 2022-02-18
 - Initial release

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0"
+        "craftcms/cms": "^3.0|^4.0"
     },
     "require-dev": {
       "codeception/codeception": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fostercommerce/entry-type-rules",
     "description": "A Craft plugin that allows you to set rules on number of entry types in a Craft section and/or limit who can include entry type entries based on their user group.",
     "type": "craft-plugin",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "keywords": [
         "craft",
         "cms",
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.7.0"
+        "craftcms/cms": "^4.0"
     },
     "require-dev": {
       "codeception/codeception": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         }
     ],
     "require": {
+        "php": "^7.2.5|^8.0",
         "craftcms/cms": "^3.0|^4.0"
     },
     "require-dev": {

--- a/src/EntryTypeRules.php
+++ b/src/EntryTypeRules.php
@@ -65,21 +65,21 @@ class EntryTypeRules extends Plugin
      *
      * @var string
      */
-    public string $schemaVersion = '1.0.0';
+    public $schemaVersion = '1.0.0';
 
     /**
      * Set to `true` if the plugin should have a settings view in the control panel.
      *
      * @var bool
      */
-    public bool $hasCpSettings = true;
+    public $hasCpSettings = true;
 
     /**
      * Set to `true` if the plugin should have its own section (main nav item) in the control panel.
      *
      * @var bool
      */
-    public bool $hasCpSection = false;
+    public $hasCpSection = false;
 
     // Public Methods
     // =========================================================================

--- a/src/EntryTypeRules.php
+++ b/src/EntryTypeRules.php
@@ -65,21 +65,21 @@ class EntryTypeRules extends Plugin
      *
      * @var string
      */
-    public $schemaVersion = '1.0.0';
+    public string $schemaVersion = '1.0.0';
 
     /**
      * Set to `true` if the plugin should have a settings view in the control panel.
      *
      * @var bool
      */
-    public $hasCpSettings = true;
+    public bool $hasCpSettings = true;
 
     /**
      * Set to `true` if the plugin should have its own section (main nav item) in the control panel.
      *
      * @var bool
      */
-    public $hasCpSection = false;
+    public bool $hasCpSection = false;
 
     // Public Methods
     // =========================================================================
@@ -95,7 +95,7 @@ class EntryTypeRules extends Plugin
      * you do not need to load it in your init() method.
      *
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
         self::$plugin = $this;
@@ -191,7 +191,7 @@ class EntryTypeRules extends Plugin
      * instead of using the general Craft settings HTML method to render the settings page.
      * @inheritdoc
      */
-    public function getSettingsResponse()
+    public function getSettingsResponse(): mixed
     {
         $overrides = Craft::$app->getConfig()->getConfigFromFile($this->handle);
 
@@ -213,7 +213,7 @@ class EntryTypeRules extends Plugin
      *
      * @return Model|null
      */
-    protected function createSettingsModel()
+    protected function createSettingsModel(): ?Model
     {
         return new Settings();
     }

--- a/src/assetbundles/entrytyperules/EntryTypeRulesAsset.php
+++ b/src/assetbundles/entrytyperules/EntryTypeRulesAsset.php
@@ -40,7 +40,7 @@ class EntryTypeRulesAsset extends AssetBundle
     /**
      * Initializes the bundle.
      */
-    public function init()
+    public function init(): void
     {
         // define the path that your publishable resources live
         $this->sourcePath = "@fostercommerce/entrytyperules/assetbundles/entrytyperules/dist";

--- a/src/assetbundles/entrytyperules/EntryTypeRulesSettingsAsset.php
+++ b/src/assetbundles/entrytyperules/EntryTypeRulesSettingsAsset.php
@@ -40,7 +40,7 @@ class EntryTypeRulesSettingsAsset extends AssetBundle
     /**
      * Initializes the bundle.
      */
-    public function init()
+    public function init(): void
     {
         // define the path that your publishable resources live
         $this->sourcePath = "@fostercommerce/entrytyperules/assetbundles/entrytyperules/dist";

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -47,7 +47,7 @@ class DefaultController extends Controller
      *         The actions must be in 'kebab-case'
      * @access protected
      */
-    protected $allowAnonymous = [];
+    protected array|int|bool $allowAnonymous = [];
 
     // Public Methods
     // =========================================================================

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -47,7 +47,7 @@ class DefaultController extends Controller
      *         The actions must be in 'kebab-case'
      * @access protected
      */
-    protected array|int|bool $allowAnonymous = [];
+    protected $allowAnonymous = [];
 
     // Public Methods
     // =========================================================================

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -58,7 +58,7 @@ class DefaultController extends Controller
      *
      * @return mixed
      */
-    public function actionIndex()
+    public function actionIndex(): mixed
     {
         $result = [
             'sectionId' => 0,

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -30,7 +30,7 @@ class SettingsController extends Controller
      *         The actions must be in 'kebab-case'
      * @access protected
      */
-    protected $allowAnonymous = [];
+    protected array|int|bool $allowAnonymous = [];
 
     /**
      * Handle a request going to our plugin's action URL for saving settings,
@@ -41,7 +41,7 @@ class SettingsController extends Controller
      * @throws NotFoundHttpException
      * @throws MissingComponentException
      */
-    public function actionSaveSettings()
+    public function actionSaveSettings(): null|\yii\web\Response
     {
         // Require posts to this controller action only
         $this->requirePostRequest();

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -30,7 +30,7 @@ class SettingsController extends Controller
      *         The actions must be in 'kebab-case'
      * @access protected
      */
-    protected array|int|bool $allowAnonymous = [];
+    protected $allowAnonymous = [];
 
     /**
      * Handle a request going to our plugin's action URL for saving settings,

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -49,7 +49,7 @@ class Settings extends Model
         ]
     ]
      */
-    public $sections = [];
+    public array|string $sections = [];
 
     // Public Methods
     // =========================================================================
@@ -64,7 +64,7 @@ class Settings extends Model
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             [['sections'], ArrayValidator::class]

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -49,7 +49,7 @@ class Settings extends Model
         ]
     ]
      */
-    public array|string $sections = [];
+    public $sections = [];
 
     // Public Methods
     // =========================================================================

--- a/src/services/EntryTypeRulesService.php
+++ b/src/services/EntryTypeRulesService.php
@@ -47,7 +47,7 @@ class EntryTypeRulesService extends Component
      * @param $sectionId
      * @return mixed
      */
-    public function getLockedEntryTypes($sectionId)
+    public function getLockedEntryTypes($sectionId): mixed
     {
         // We will return an array of locked entry type IDs
         $lockedEntryTypes = [];
@@ -111,7 +111,7 @@ class EntryTypeRulesService extends Component
      * @return array
      * @throws InvalidConfigException
      */
-    public function formatSectionsSettings($formParams)
+    public function formatSectionsSettings($formParams): array
     {
         $sections = [];
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -57,7 +57,7 @@
         value: 'entry-type-rules'})
     }}
 
-    {% for section in sections if section.type != 'single' %}
+    {% for section in sections | filter(section =>  section.type != 'single') %}
 
         {% if not loop.first %}<hr />{% endif %}
 


### PR DESCRIPTION
I have updated the plugin to be installable in Craft 4 and checked the functionality is working. I have also installed the Craft 3 version and compared the functionality to that version.

Since I don't know this plugin inside-out, I would appreciate if someone could take a look to ensure it still does everything they expect it to!

I have tested:

- [x] I can install the plugin
- [x] I can configure the plugin to limit the number of entries of a particular type
- [x] The entry type dropdown options are disabled if the limit for that type is reached
- [x] The entry types are limited by user group
- [x] I can disable the plugin and re-enable it
- [x] I can uninstall the plugin and reinstall it
- [x] I have bumped the version number and updated the changelog